### PR TITLE
Remember more gui state

### DIFF
--- a/dottorrentGUI/gui.py
+++ b/dottorrentGUI/gui.py
@@ -194,6 +194,16 @@ class DottorrentGUI(Ui_MainWindow):
         source = settings.value('options/source')
         if source:
             self.sourceEdit.setText(source)
+        compute_md5 = bool(int(settings.value('options/compute_md5') or 0))
+        if compute_md5:
+            self.md5CheckBox.setChecked(compute_md5)
+        mainwindow_size = settings.value("geometry/size")
+        if mainwindow_size:
+            self.MainWindow.resize(mainwindow_size)
+
+        mainwindow_position = settings.value("geometry/position")
+        if mainwindow_position:
+            self.MainWindow.move(mainwindow_position)
         self.last_input_dir = settings.value('history/last_input_dir') or None
         self.last_output_dir = settings.value(
             'history/last_output_dir') or None
@@ -208,6 +218,9 @@ class DottorrentGUI(Ui_MainWindow):
         settings.setValue('options/private',
                           int(self.privateTorrentCheckBox.isChecked()))
         settings.setValue('options/source', self.sourceEdit.text())
+        settings.setValue('options/compute_md5', int(self.md5CheckBox.isChecked()))
+        settings.setValue('geometry/size', self.MainWindow.size())
+        settings.setValue('geometry/position', self.MainWindow.pos())
         if self.last_input_dir:
             settings.setValue('history/last_input_dir', self.last_input_dir)
         if self.last_output_dir:

--- a/dottorrentGUI/gui.py
+++ b/dottorrentGUI/gui.py
@@ -475,12 +475,14 @@ class DottorrentGUI(Ui_MainWindow):
             trackers = self.trackerEdit.toPlainText().strip().split()
             web_seeds = self.webSeedEdit.toPlainText().strip().split()
             private = self.privateTorrentCheckBox.isChecked()
+            compute_md5 = self.md5CheckBox.isChecked()
             source = self.sourceEdit.text()
             data = {
                 'exclude': exclude,
                 'trackers': trackers,
                 'web_seeds': web_seeds,
                 'private': private,
+                'compute_md5': compute_md5,
                 'source': source
             }
             with open(fn, 'w') as f:
@@ -498,12 +500,14 @@ class DottorrentGUI(Ui_MainWindow):
             trackers = data.get('trackers', [])
             web_seeds = data.get('web_seeds', [])
             private = data.get('private', False)
+            compute_md5 = data.get('compute_md5', False)
             source = data.get('source', '')
             try:
                 self.excludeEdit.setPlainText(os.linesep.join(exclude))
                 self.trackerEdit.setPlainText(os.linesep.join(trackers))
                 self.webSeedEdit.setPlainText(os.linesep.join(web_seeds))
                 self.privateTorrentCheckBox.setChecked(private)
+                self.md5CheckBox.setChecked(compute_md5)
                 self.sourceEdit.setText(source)
             except Exception as e:
                 self._showError(str(e))

--- a/dottorrentGUI/gui.py
+++ b/dottorrentGUI/gui.py
@@ -200,7 +200,6 @@ class DottorrentGUI(Ui_MainWindow):
         mainwindow_size = settings.value("geometry/size")
         if mainwindow_size:
             self.MainWindow.resize(mainwindow_size)
-
         mainwindow_position = settings.value("geometry/position")
         if mainwindow_position:
             self.MainWindow.move(mainwindow_position)


### PR DESCRIPTION
I often use dottorrent-gui, and a minor pain point I had was that, upon reopening the application, I always had to resize the window and recheck the "Computer md5" checkbox. So, I decided to do something about it, and here we are.

This pull request adds 2 little things:

1. When exporting a profile, the md5Checkbox state is also saved in the `.json` file, so that it can be restored when importing the profile
2. When closing the application, we save the window size, the window position, and the md5Checkbox state, so that it can be restored when opening the application in the future.

I hope these changes are OK, if not, then it's alright.

-Raphaël