### PR TITLE
Move portable configuration to a dedicated folder

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Portable Mode
 -------------
 
 dottorrent-gui can be configured to run in portable mode, good for running from USB drives and network shares.
-To enable this, simply create an empty file named ``dottorrent-gui.ini`` in the same directory as the
+To enable this, simply create a folder named ``data`` in the same directory as the
 main excecutable.
 
 -------

--- a/dottorrentGUI/gui.py
+++ b/dottorrentGUI/gui.py
@@ -166,8 +166,11 @@ class DottorrentGUI(Ui_MainWindow):
 
     def getSettings(self):
         portable_fn = PROGRAM_NAME + '.ini'
-        portable_fn = os.path.join(_basedir, portable_fn)
-        if os.path.exists(portable_fn):
+        portable_dn = os.path.join(_basedir, 'data')
+        if os.path.exists(portable_dn):
+            portable_fn = os.path.join(portable_dn, portable_fn)
+            if not os.path.exists(portable_fn):
+                open(portable_fn, 'a').close()
             return QtCore.QSettings(
                 portable_fn,
                 QtCore.QSettings.IniFormat


### PR DESCRIPTION
As a workaround for #39 move all portable configuration to its own dedicated folder which won't be recreating itself on settings save. This is also beneficial when dealing with more than just one config file, for example if #36 ever gets implemented.